### PR TITLE
Note that the password grant can only be used by confidential clients

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -97,6 +97,10 @@ Using the password grant involves:
 The Password Grant flow can only be used to access your own account. Use the [Authorization Code Grant](#web-application-flow-authorization-code-grant) to request access to another Mondo user's account.
 </aside>
 
+<aside class="notice">
+The Password Grant flow can only be used with confidential clients. Make sure you select confidential when creating a new client, and do not expose the client secret.
+</aside>
+
 ### Acquiring an access token
 
 ```shell


### PR DESCRIPTION
Trying to use the password grant (`grant_type=password`) with a non confidential client isn't permitted, and will return the below error if you try to authorise in this way:

```
{
    "error":"unauthorized_client",
    "error_description":"Client does not have permission to use the requested grant",
    "message":"Client does not have permission to use the requested grant"
}
```