### PR TITLE
Use form encoding in transaction annotation call

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -123,7 +123,7 @@ Pagination<br><span class="label">Optional</span>|This endpoint can be [paginate
 ## Annotate transaction
 
 ```shell
-$ http PATCH "https://api.getmondo.co.uk/transactions/$transaction_id" \
+$ http --form PATCH "https://api.getmondo.co.uk/transactions/$transaction_id" \
     "Authorization: Bearer $access_token" \
     "metadata[$key1]=$value1" \
     # Set a key's value as empty to delete it


### PR DESCRIPTION
Without the `--form` option the request body is sent json-encoded, which the API doesn't support.