### PR TITLE
Correct examples where GET requests incorrectly execute as POST

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -21,7 +21,7 @@ Most properties on transactions are self-explanatory. We'll eventually get aroun
 $ http "https://api.getmondo.co.uk/transactions/$transaction_id" \
     "Authorization: Bearer $access_token" \
     # Here we are expanding the merchant \
-    "expand[]=merchant"
+    "expand[]==merchant"
 ```
 
 ```json
@@ -71,7 +71,7 @@ Returns an individual transaction, fetched by its id.
 ## List transactions
 
 ```shell
-$ http "https://api.getmondo.co.uk/transactions" \
+$ http "https://api.getmondo.co.uk/transactions?account_id=$account_id" \
     "Authorization: Bearer $access_token" \
     "account_id=$account_id"
 ```

--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -72,8 +72,7 @@ Returns an individual transaction, fetched by its id.
 
 ```shell
 $ http "https://api.getmondo.co.uk/transactions?account_id=$account_id" \
-    "Authorization: Bearer $access_token" \
-    "account_id=$account_id"
+    "Authorization: Bearer $access_token"
 ```
 
 ```json


### PR DESCRIPTION
Someone noticed the HTTPie example for listing transactions returns `Method not allowed`, turns out HTTPie defaults to `POST` if params are passed with a single `=`.

This changes the examples to use query string params where appropriate, and `==` elsewhere.

Shout-out to @domwong  for his HTTPie knowledge