### PR TITLE
[WF-1984] docs: inline regex match arg to satisfy uglifier

### DIFF
--- a/source/javascripts/lib/_cookie_banner.js
+++ b/source/javascripts/lib/_cookie_banner.js
@@ -5,9 +5,7 @@
   var MAX_AGE = 365 * 24 * 60 * 60;
 
   function getCookie(name) {
-    var match = document.cookie.match(
-      new RegExp("(?:^|; )" + name + "=([^;]*)"),
-    );
+    var match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
     return match ? match[1] : null;
   }
 


### PR DESCRIPTION
The build minifier (uglifier 4.x) doesn't support trailing commas in
function call argument lists, causing the all_nosearch.js and all.js
bundles to fail to write during production build.

Serves me right for trying to use modern syntax (from 2015)!
