### PR TITLE
add comment on correct InstructedAmount

### DIFF
--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -173,6 +173,8 @@ We've implemented version 3.1.11 of the [Open Banking International Payments spe
 }
 ```
 
+You can only specify payments in GBP (`InstructedAmount.Currency`), while the destination currency (`CurrencyOfTransfer`) must be one of the supported currencies listed in the table below.
+
 Note that we only support indicative exchange rates (`ExchangeRateInformation.RateType` must be set to `Indicative`).
 
 ### International Payment currencies and rails support

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -173,7 +173,7 @@ We've implemented version 3.1.11 of the [Open Banking International Payments spe
 }
 ```
 
-You can only specify payments in GBP (`InstructedAmount.Currency`), while the destination currency (`CurrencyOfTransfer`) must be one of the supported currencies listed in the table below.
+You can only specify payment amounts in GBP (`InstructedAmount.Currency`), while the destination currency (`CurrencyOfTransfer`) must be one of the supported currencies listed in the table below.
 
 Note that we only support indicative exchange rates (`ExchangeRateInformation.RateType` must be set to `Indicative`).
 


### PR DESCRIPTION
We see some TPP enter not supported currency in `InstructedAmount.Currency` (we only support GBP atm), that results in validation error.

This PR makes it clear what are supported values for `InstructedAmount.Currency`