### PR TITLE
Open Banking for EU: update docs to say it's not alpha

### DIFF
--- a/source/includes/_eu.md
+++ b/source/includes/_eu.md
@@ -1,10 +1,5 @@
 # EU PSD2 API
 
-<aside class="notice">
-    Alongside the sandbox testing environment, Monzo's production EU PSD2 Dedicated Interface API is now available in an Alpha Capacity for Account Information Services (AIS), Payment Initiation Services (PIS), and Confirmation of Funds (CBPII). Please get in touch with us at <a href="mailto:openbanking@monzo.com">openbanking@monzo.com</a> if you'd like to integrate with us and test out our APIs. Access to the production environment is controlled by an allow-list at this time, so please contact us to get added.
-</aside>
-
-
 ## API Specification
 
 Like our UK Open Banking API, our EU PSD2 Dedicated Interface is also built to the [Open Banking spec](https://openbankinguk.github.io/read-write-api-site3/v3.1.11/profiles/read-write-data-api-profile.html). This means the structure of requests and responses is for the most part the same, with any differences reflecting product differences between UK and EU regions.

--- a/source/open-banking/index.html.md
+++ b/source/open-banking/index.html.md
@@ -23,7 +23,11 @@ Monzo's Open Banking API allows licensed [Third Party Providers](https://www.ope
 
 If you need support with Monzo's Open Banking API, please create a ticket on the [Open Banking Service Desk](https://directory.openbanking.org.uk/obieservicedesk/s/), or contact <openbanking@monzo.com>.
 
+<aside class="notice">
+    These are the docs for Monzo's <strong>UK Open Banking API</strong>. If you're looking to integrate with our EU region, see the <a href="#eu-psd2-api">EU PSD2 API</a> instead.
+</aside>
+
 <aside class="warning">
     <strong>Not a licensed Open Banking Third Party Provider?</strong><br>
-    These are the docs for Monzo's Open Banking API. Check out <a href="/">the docs for our public developer API</a> that anyone can use.
+    Check out <a href="/">the docs for our public developer API</a> that anyone can use.
 </aside>

--- a/source/open-banking/index.html.md
+++ b/source/open-banking/index.html.md
@@ -24,7 +24,7 @@ Monzo's Open Banking API allows licensed [Third Party Providers](https://www.ope
 If you need support with Monzo's Open Banking API, please create a ticket on the [Open Banking Service Desk](https://directory.openbanking.org.uk/obieservicedesk/s/), or contact <openbanking@monzo.com>.
 
 <aside class="notice">
-    These are the docs for Monzo's <strong>UK Open Banking API</strong>. If you're looking to integrate with our EU region, see the <a href="#eu-psd2-api">EU PSD2 API</a> instead.
+    These are the docs for Monzo's <strong>UK Open Banking API</strong>. If you're looking to integrate with our EU region, please go to the <a href="#eu-psd2-api">EU PSD2 API</a> section.
 </aside>
 
 <aside class="warning">


### PR DESCRIPTION
As we have seen succesfull integration with TPPs, we have removed allowlist  and we are no longer in Alpha Capacity.

This PR
* updates docs to reflect it's no longer alpha 
* add a link to EU section to the top, to avoid confusion with UK vs EU